### PR TITLE
Fix Medium Size Topology: 2 Masters and 40 Executors

### DIFF
--- a/mainTemplate.json
+++ b/mainTemplate.json
@@ -99,8 +99,8 @@
       "vmImageSku": "jenkins-operations-center-small"
     },
     "clusterSpecMedium": {
-      "numberOfMasters": 3,
-      "numberOfExecutors": 50,
+      "numberOfMasters": 2,
+      "numberOfExecutors": 40,
       "vmImageSku": "jenkins-operations-center-medium"
       },
     "clusterSpecLarge": {


### PR DESCRIPTION
Fix Medium Size Topology: 2 Masters and 40 Executors instead of 3 Masters and 50 Executors.