### PR TITLE
[AL-8] Fix random errors caused by $JENKINS_HOME/atomicXXX.tmp files

### DIFF
--- a/setup-master.sh
+++ b/setup-master.sh
@@ -6,7 +6,7 @@ set -e
 # Copyright (c) 2016, CloudBees, Inc.
 #
 
-# 
+#
 # Azure ARM setup script to prepare a CJE VM for integration for integration within CJP
 #
 # usage:
@@ -25,7 +25,7 @@ mkdir -p /var/lib/jenkins/plugins
 touch /var/lib/jenkins/plugins/cloudbees-license.jpi.pinned
 curl $rooturl/cloudbees-license.hpi -o /var/lib/jenkins/plugins/cloudbees-license.jpi
 curl $rooturl/client-master-marketplace-licensing.hpi -o /var/lib/jenkins/plugins/client-master-marketplace-licensing.hpi
-chown -R jenkins:jenkins /var/lib/jenkins/
+chown -Rf jenkins:jenkins /var/lib/jenkins/
 
 
 CFG="/var/lib/jenkins/com.cloudbees.opscenter.client.plugin.OperationsCenterRootAction.xml"

--- a/setup-operations-center.sh
+++ b/setup-operations-center.sh
@@ -48,7 +48,7 @@ INIT=/var/lib/jenkins-oc/init.groovy.d/security-realm-azure.groovy
 curl $rooturl/security-realm-azure.groovy -o $INIT
 sed -i "s/__REPLACE_WITH_PASSWORD__/$adminPassword/" "$INIT"
 
-chown -R jenkins-oc:jenkins-oc /var/lib/jenkins-oc/
+chown -Rf jenkins-oc:jenkins-oc /var/lib/jenkins-oc/
 
 
 # Configure Jenkins root URL
@@ -79,4 +79,3 @@ echo "    size: $size" >> /var/lib/jenkins-oc/.cloudbees-referrer.txt
 echo "    subscriptionId: $subscription" >> /var/lib/jenkins-oc/.cloudbees-referrer.txt
 
 /etc/init.d/jenkins-oc restart
-


### PR DESCRIPTION
https://cloudbees.atlassian.net/browse/AL-8

Jenkins creates temporary "$JENKINS_HOME/atomicXXX.tmp" files, "chmod" should not fail if they disappear during the "chmod".

A longer term fix will be to ensure that Jenkins is stopped while upgrading $JENKINS_HOME.